### PR TITLE
docs: Add comprehensive module-level docstring to pyasl.modules

### DIFF
--- a/PyASL/pyasl/modules/__init__.py
+++ b/PyASL/pyasl/modules/__init__.py
@@ -1,0 +1,47 @@
+"""
+ASL Processing Modules
+======================
+
+This package contains processing modules for Arterial Spin Labeling (ASL) MRI data.
+
+The modules are organized by their source pipeline:
+
+**ASLtbx** - SPM-based ASL processing pipeline
+    Includes coregister, create_mask, perfusion_quantify, realign, 
+    reset_orientation, and smooth modules.
+
+**DL-ASL** - Deep learning-based ASL processing
+    Provides build_mask and denoise_cbf for AI-powered processing.
+
+**MRICloud** - Cloud-based ASL quantification pipeline
+    Offers comprehensive quantification tools including calculate_CBF, calculate_M0,
+    calculate_diffmap, coreg_mpr, multidelay variants, read_mpr, rescale,
+    and t1roi_CBFaverage.
+
+**Oxford ASL** - BASIL-based ASL analysis
+    Features asl_run and asl_split_m0 for model-based analysis.
+
+**Preclinical** - Modules for preclinical ASL data
+    A complete suite for animal imaging including abs_t1fit, brain_mask,
+    cbf_relative, compute_m0, control_label_split, diff_image, loader functions
+    for Bruker and NIfTI formats, motion_check, slice_pld_adjust, and 
+    steady_state_trim.
+
+**Utilities**
+    Common functionality like save_outputs.
+
+Each module can be used independently or combined to build custom processing
+pipelines tailored to your specific ASL acquisition and analysis needs.
+
+Example Usage
+-------------
+You can import specific modules as needed:
+
+    from pyasl.modules import asltbx_coregister
+    from pyasl.modules import mricloud_calculate_CBF
+
+See Also
+--------
+pyasl.pipelines : Ready-to-use processing pipelines
+pyasl.utils : Data handling utilities
+"""


### PR DESCRIPTION
## Summary
Added module-level documentation to the previously empty `pyasl/modules/__init__.py` file to improve code discoverability and help new contributors understand the package structure.

## Changes
- Document the purpose of the modules package
- List all available modules organized by their source pipeline (ASLtbx, DL-ASL, MRICloud, Oxford ASL, Preclinical)
- Add usage examples for importing modules
- Improve package discoverability for new users

## Motivation
The `__init__.py` file was completely empty, making it difficult for developers to:
- Discover what modules are available
- Understand how modules are organized
- Know which pipeline each module belongs to

This documentation provides a clear overview and helps users navigate the codebase more effectively.

## Testing
- [x] File follows Python docstring conventions
- [x] Documentation is clear and informative
- [x] All module names are accurately listed

## Additional Context
I am interested in contributing to the OSIPI project and the AURA Platform GSoC 2026 project. This is my first contribution to help familiarize myself with the codebase.