### PR TITLE
fix: replace f-string logger calls with lazy % formatting

### DIFF
--- a/PyASL/pyasl/modules/oxford_asl_split_m0.py
+++ b/PyASL/pyasl/modules/oxford_asl_split_m0.py
@@ -75,7 +75,7 @@ class OxfordASLSplitM0:
             if not m0_path or not os.path.exists(m0_path):
                 raise ValueError("ASLContext has no 'm0scan' and no separate M0 found in data_descrip['Images'][base]['M0'].")
 
-            logger.info(f"[OxfordASL::SplitM0] No 'm0scan' found; pass-through. asl={in_asl} m0={m0_path}")
+            logger.info("[OxfordASL::SplitM0] No 'm0scan' found; pass-through. asl=%s m0=%s", in_asl, m0_path)
             return {"asl_path": in_asl, "m0_path": m0_path}
 
         der_dir = _deriv_dir(base_dir)
@@ -96,5 +96,5 @@ class OxfordASLSplitM0:
         nib.Nifti1Image(asl_data, V.affine, V.header).to_filename(out_asl)
         nib.Nifti1Image(m0_data,  V.affine, V.header).to_filename(out_m0)
 
-        logger.info(f"[OxfordASL::SplitM0] in={in_asl} -> asl={out_asl}  m0={out_m0}")
+        logger.info("[OxfordASL::SplitM0] in=%s -> asl=%s  m0=%s", in_asl, out_asl, out_m0)
         return {"asl_path": out_asl, "m0_path": out_m0}

--- a/PyASL/pyasl/modules/save_outputs.py
+++ b/PyASL/pyasl/modules/save_outputs.py
@@ -21,4 +21,4 @@ class SaveOutputs():
         if p.get("config_echo"):
             with open(os.path.join(savedir, "config_echo.yaml"), "w") as f:
                 f.write(p["config_echo"])
-        logger.info(f"[SaveOutputs] Saved to {savedir}")
+        logger.info("[SaveOutputs] Saved to %s", savedir)

--- a/PyASL/pyasl/pipelines/run_pipeline.py
+++ b/PyASL/pyasl/pipelines/run_pipeline.py
@@ -102,7 +102,7 @@ def _resolve_runner(pipeline_type: str) -> Callable[[str, str], object]:
     # Check registry first
     if key in _PIPELINE_REGISTRY:
         mod_name, func_name = _PIPELINE_REGISTRY[key]
-        logger.info(f"Using registry: {key} -> {mod_name}.{func_name}()")
+        logger.info("Using registry: %s -> %s.%s()", key, mod_name, func_name)
         mod = importlib.import_module(mod_name)
         fn = getattr(mod, func_name, None)
         if not callable(fn):
@@ -111,7 +111,7 @@ def _resolve_runner(pipeline_type: str) -> Callable[[str, str], object]:
 
     # Fallback: convention
     mod_name, func_candidates = _convention_candidates(key)
-    logger.info(f"Trying convention: module={mod_name}, funcs={func_candidates}")
+    logger.info("Trying convention: module=%s, funcs=%s", mod_name, func_candidates)
     try:
         mod = importlib.import_module(mod_name)
     except ModuleNotFoundError:
@@ -121,7 +121,7 @@ def _resolve_runner(pipeline_type: str) -> Callable[[str, str], object]:
         for fname in func_candidates:
             fn = getattr(mod, fname, None)
             if callable(fn):
-                logger.info(f"Resolved by convention: {mod_name}.{fname}()")
+                logger.info("Resolved by convention: %s.%s()", mod_name, fname)
                 return fn
 
     # Nothing worked
@@ -153,11 +153,11 @@ def run_pipeline(input_dir: str, config_path: str) -> object:
     if not ptype:
         raise KeyError("Config YAML must include a top-level 'type' field.")
 
-    logger.info(f"Pipeline type: {ptype}")
+    logger.info("Pipeline type: %s", ptype)
     runner = _resolve_runner(ptype)
 
     # Forward arguments as-is
-    logger.info(f"Dispatching to runner with input='{input_p}', config='{cfg_p}'")
+    logger.info("Dispatching to runner with input='%s', config='%s'", input_p, cfg_p)
     return runner(str(input_p), str(cfg_p))
 
 


### PR DESCRIPTION
Closes #6

Logger calls were using f-strings which eagerly evaluate the string even when the log level is disabled. Replace with lazy %-style formatting so the string is only built if the message is emitted.